### PR TITLE
Update s3_checks.rs

### DIFF
--- a/src/ch5_channels/s3_checks.rs
+++ b/src/ch5_channels/s3_checks.rs
@@ -42,7 +42,11 @@ impl<T> Channel<T> {
             panic!("no message available!");
         }
         // Safety: We've just checked (and reset) the ready flag.
-        unsafe { (*self.message.get()).assume_init_read() }
+        unsafe { 
+            let v = (*self.message.get()).assume_init_read();
+            self.in_use.store(false, Release);
+            v
+        }
     }
 }
 


### PR DESCRIPTION
The issue in the code is that the in_use flag is not reset after the first message is sent and received. 
This flag prevents sending more than one message, which causes the panic in the second attempt.
To fix this, you need to reset the in_use flag to false after the message has been consumed in the receive method.

