### PR TITLE
chapter 2 example - document that generated key must not be 0

### DIFF
--- a/examples/ch2-13-lazy-one-time-init.rs
+++ b/examples/ch2-13-lazy-one-time-init.rs
@@ -6,6 +6,7 @@ fn get_key() -> u64 {
     let key = KEY.load(Relaxed);
     if key == 0 {
         let new_key = generate_random_key();
+        debug_assert_ne!(new_key, 0);
         match KEY.compare_exchange(0, new_key, Relaxed, Relaxed) {
             Ok(_) => new_key,
             Err(k) => k,


### PR DESCRIPTION
In the (source code of the) book, I think it would make sense to document in some way that `new_key` mustn't be `0`; otherwise `get_key()` will not work correctly